### PR TITLE
Fix build for automake 1.16.5

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,10 +1,9 @@
 dnl Process this file with autoconf to produce a configure script.
 AC_INIT(mpk3-settings,0.1,,)
-AM_INIT_AUTOMAKE([foreign])
 AC_PREREQ(2.69)
 AC_CONFIG_HEADERS(config.h)
 AC_GNU_SOURCE
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([subdir-objects])
 CFLAGS=""
 AC_SUBST(CFLAGS)
 AC_PROG_CC


### PR DESCRIPTION
Hi, I couldn't build on my Debian Testing system.
Autogen step had this error:
```
./autogen.sh 
Running aclocal...
configure.ac:7: error: AM_INIT_AUTOMAKE expanded multiple times
/usr/share/aclocal-1.16/init.m4:29: AM_INIT_AUTOMAKE is expanded from...
configure.ac:3: the top level
/usr/share/aclocal-1.16/init.m4:29: AM_INIT_AUTOMAKE is expanded from...
configure.ac:7: the top level
autom4te: error: /usr/bin/m4 failed with exit status: 1
aclocal: error: autom4te failed with exit status: 1
```

After googling a bit I found a recent similar error here: https://github.com/mikebrady/shairport-sync/issues/1368
This PR adds a fix as per https://github.com/mikebrady/shairport-sync/pull/1314/commits/424cc398240c18e95c26edda1dd565c5915e4c1c

Other than than I'd like to report that the software works perfectly :) Thank you very much!