### PR TITLE
Fixing various bugs

### DIFF
--- a/src/app_win.c
+++ b/src/app_win.c
@@ -327,16 +327,16 @@ static GtkWidget *joystick_ui_create(void)
 
 	gtk_grid_attach(GTK_GRID(grid), h_mode_combo, 0, 0, 4, 1);
 	gtk_grid_attach(GTK_GRID(grid), h_neg_icon,   0, 1, 1, 1);
-	gtk_grid_attach(GTK_GRID(grid), h_label,      1, 1, 1, 1);
-	gtk_grid_attach(GTK_GRID(grid), h_neg_entry,  2, 1, 2, 1);
+	gtk_grid_attach(GTK_GRID(grid), h_label,      0, 1, 1, 1);
+	gtk_grid_attach(GTK_GRID(grid), h_neg_entry,  1, 1, 2, 1);
 	gtk_grid_attach(GTK_GRID(grid), h_pos_icon,   0, 2, 1, 1);
-	gtk_grid_attach(GTK_GRID(grid), h_pos_entry,  2, 2, 2, 1);
+	gtk_grid_attach(GTK_GRID(grid), h_pos_entry,  1, 2, 2, 1);
 	gtk_grid_attach(GTK_GRID(grid), v_mode_combo, 0, 3, 4, 1);
 	gtk_grid_attach(GTK_GRID(grid), v_pos_icon,   0, 4, 1, 1);
-	gtk_grid_attach(GTK_GRID(grid), v_label,      1, 5, 1, 1);
-	gtk_grid_attach(GTK_GRID(grid), v_pos_entry,  2, 4, 2, 1);
+	gtk_grid_attach(GTK_GRID(grid), v_label,      0, 5, 1, 1);
+	gtk_grid_attach(GTK_GRID(grid), v_pos_entry,  1, 4, 2, 1);
 	gtk_grid_attach(GTK_GRID(grid), v_neg_icon,   0, 5, 1, 1);
-	gtk_grid_attach(GTK_GRID(grid), v_neg_entry,  2, 5, 2, 1);
+	gtk_grid_attach(GTK_GRID(grid), v_neg_entry,  1, 5, 2, 1);
 
 	gtk_combo_box_text_append(GTK_COMBO_BOX_TEXT(h_mode_combo), "0", "Pitchbend");
 	gtk_combo_box_text_append(GTK_COMBO_BOX_TEXT(h_mode_combo), "1", "Single CC");

--- a/src/app_win.c
+++ b/src/app_win.c
@@ -292,10 +292,10 @@ static GtkWidget *joystick_ui_create(void)
 	GtkWidget *grid = gtk_grid_new();
 	GtkWidget *h_mode_combo = gtk_combo_box_text_new();
 	GtkWidget *h_pos_entry = gtk_spin_button_new_with_range(CHANNEL_MIN, CHANNEL_MAX, 1.0);
-	GtkWidget *h_pos_icon = gtk_image_new_from_icon_name("go-right", GTK_ICON_SIZE_MENU);
+	GtkWidget *h_pos_icon = gtk_image_new_from_icon_name("go-next", GTK_ICON_SIZE_MENU);
 	GtkWidget *h_label = gtk_label_new("CC");
 	GtkWidget *h_neg_entry = gtk_spin_button_new_with_range(CHANNEL_MIN, CHANNEL_MAX, 1.0);
-	GtkWidget *h_neg_icon = gtk_image_new_from_icon_name("go-left", GTK_ICON_SIZE_MENU);
+	GtkWidget *h_neg_icon = gtk_image_new_from_icon_name("go-previous", GTK_ICON_SIZE_MENU);
 	GtkWidget *v_mode_combo = gtk_combo_box_text_new();
 	GtkWidget *v_pos_entry = gtk_spin_button_new_with_range(CHANNEL_MIN, CHANNEL_MAX, 1.0);
 	GtkWidget *v_pos_icon = gtk_image_new_from_icon_name("go-up", GTK_ICON_SIZE_MENU);

--- a/src/app_win.c
+++ b/src/app_win.c
@@ -209,8 +209,8 @@ static GtkWidget *toolbar_create(void)
 {
 	GtkWidget *toolbar_vbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
 	GtkWidget *pgm_selector = gtk_combo_box_text_new();
-	GtkWidget *read_pgm_button = gtk_button_new_from_icon_name("document-open", GTK_ICON_SIZE_BUTTON);
-	GtkWidget *write_pgm_button = gtk_button_new_from_icon_name("document-save", GTK_ICON_SIZE_BUTTON);
+	GtkWidget *read_pgm_button = gtk_button_new_from_icon_name("folder-download-symbolic", GTK_ICON_SIZE_BUTTON);
+	GtkWidget *write_pgm_button = gtk_button_new_from_icon_name("send-to-symbolic", GTK_ICON_SIZE_BUTTON);
 	GtkWidget *pgm_name_label = gtk_label_new("Program name:");
 	GtkWidget *pgm_name_entry = gtk_entry_new();
 	gchar pgm_label[] = "Program #";

--- a/src/app_win.c
+++ b/src/app_win.c
@@ -269,8 +269,8 @@ static void on_joystick_mode_combo_changed(GtkWidget *combo, gpointer user_data)
 			gtk_widget_hide(ui->pos_icon);
 			gtk_widget_hide(ui->neg_icon);
 			gtk_widget_show(ui->cc_label);
-			gtk_widget_show(ui->pos_entry);
-			gtk_widget_hide(ui->neg_entry);
+			gtk_widget_show(ui->neg_entry);
+			gtk_widget_hide(ui->pos_entry);
 			break;
 		case 2:
 			gtk_widget_show(ui->pos_icon);
@@ -326,14 +326,14 @@ static GtkWidget *joystick_ui_create(void)
 	g_signal_connect((gpointer)v_mode_combo, "changed", G_CALLBACK(on_joystick_mode_combo_changed), ui[JOY_UI_VERTICAL]);
 
 	gtk_grid_attach(GTK_GRID(grid), h_mode_combo, 0, 0, 4, 1);
-	gtk_grid_attach(GTK_GRID(grid), h_pos_icon,   0, 1, 1, 1);
+	gtk_grid_attach(GTK_GRID(grid), h_neg_icon,   0, 1, 1, 1);
 	gtk_grid_attach(GTK_GRID(grid), h_label,      1, 1, 1, 1);
-	gtk_grid_attach(GTK_GRID(grid), h_pos_entry,  2, 1, 2, 1);
-	gtk_grid_attach(GTK_GRID(grid), h_neg_icon,   0, 2, 1, 1);
-	gtk_grid_attach(GTK_GRID(grid), h_neg_entry,  2, 2, 2, 1);
+	gtk_grid_attach(GTK_GRID(grid), h_neg_entry,  2, 1, 2, 1);
+	gtk_grid_attach(GTK_GRID(grid), h_pos_icon,   0, 2, 1, 1);
+	gtk_grid_attach(GTK_GRID(grid), h_pos_entry,  2, 2, 2, 1);
 	gtk_grid_attach(GTK_GRID(grid), v_mode_combo, 0, 3, 4, 1);
 	gtk_grid_attach(GTK_GRID(grid), v_pos_icon,   0, 4, 1, 1);
-	gtk_grid_attach(GTK_GRID(grid), v_label,      1, 4, 1, 1);
+	gtk_grid_attach(GTK_GRID(grid), v_label,      1, 5, 1, 1);
 	gtk_grid_attach(GTK_GRID(grid), v_pos_entry,  2, 4, 2, 1);
 	gtk_grid_attach(GTK_GRID(grid), v_neg_icon,   0, 5, 1, 1);
 	gtk_grid_attach(GTK_GRID(grid), v_neg_entry,  2, 5, 2, 1);

--- a/src/app_win.c
+++ b/src/app_win.c
@@ -562,6 +562,8 @@ static GtkWidget *arpeggiator_ui_create(void)
 	GtkWidget *grid = gtk_grid_new();
 	GtkWidget *arp_switch_label = gtk_label_new("On / Off");
 	GtkWidget *arp_switch = gtk_switch_new();
+	gtk_widget_set_halign(arp_switch, GTK_ALIGN_START);
+	gtk_widget_set_valign(arp_switch, GTK_ALIGN_CENTER);
 	GtkWidget *tempo_taps_label = gtk_label_new("Tempo taps");
 	GtkWidget *tempo_label = gtk_label_new("Tempo");
 	GtkWidget *time_div_label = gtk_label_new("Time div");

--- a/src/device.c
+++ b/src/device.c
@@ -121,7 +121,7 @@ error:
 
 
 #define DEV_NAME_MAX_LEN 64
-void device_init(void)
+int device_init(void)
 {
 	guint dev_count;
 #ifdef HAVE_RTMIDI4
@@ -153,7 +153,7 @@ void device_init(void)
 	if (!found) {
 		g_critical("No MPKmini MK3 device found");
 		rtmidi_in_free(midi_in);
-		return;
+		return -1;
 	}
 	g_debug("Using device %d: %s", i, dev_name);
 	midi_out = rtmidi_out_create_default();
@@ -167,6 +167,8 @@ void device_init(void)
 
 	dev.in = midi_in;
 	dev.out = midi_out;
+
+	return 0;
 }
 
 

--- a/src/device.h
+++ b/src/device.h
@@ -1,7 +1,7 @@
 #ifndef _DEVICE_H
 #define _DEVICE_H
 
-void device_init(void);
+int device_init(void);
 void device_close(void);
 gint device_read_pgm(gint pgm_num);
 gint device_write_pgm(gint pgm_num);

--- a/src/main.c
+++ b/src/main.c
@@ -26,7 +26,10 @@ int main(int argc, char ** argv)
 	GtkWidget *app_win;
 	
 	gtk_init(&argc, &argv);
-	device_init();
+	if (device_init() < 0) {
+		show_error();
+		return -1;
+	}
 	if (device_read_pgm(PGM_NUM_RAM) < 0) {
 		show_error();
 		return -1;

--- a/src/message.h
+++ b/src/message.h
@@ -27,11 +27,11 @@
 #define OFF_TEMPO_BPM             35 /* Two 7 bit values for BPM (60 - 240) */
 #define OFF_ARP_OCTAVE            37 /* Arpeggiatior octave setting */
 #define OFF_JOY_HORIZ_MODE        38 /* Joystick horizontal mode: 0x0 pitchbend, 0x1 single, 0x2 dual */
-#define OFF_JOY_HORIZ_POSITIVE_CH 39 /* Joystick horizontal positive channel */
-#define OFF_JOY_HORIZ_NEGATIVE_CH 40 /* Joystick horizontal positive channel */
+#define OFF_JOY_HORIZ_NEGATIVE_CH 39 /* Joystick horizontal negative channel */
+#define OFF_JOY_HORIZ_POSITIVE_CH 40 /* Joystick horizontal positive channel */
 #define OFF_JOY_VERT_MODE         41 /* Joystick vertical mode: 0x0 pitchbend, 0x1 single, 0x2 dual */
-#define OFF_JOY_VERT_POSITIVE_CH  42 /* Joystick vertical positive channel */
-#define OFF_JOY_VERT_NEGATIVE_CH  43 /* Joystick vertical positive channel */
+#define OFF_JOY_VERT_NEGATIVE_CH  42 /* Joystick vertical negative channel */
+#define OFF_JOY_VERT_POSITIVE_CH  43 /* Joystick vertical positive channel */
 #define OFF_PAD_1_NOTE            44 /* Pad 1 note */
 #define OFF_PAD_1_PC              45 /* Pad 1 PC */
 #define OFF_PAD_1_CC              46 /* Pad 1 CC */


### PR DESCRIPTION
Fix joystick channel order

The positive and negative directions were reversed.
Reorder the channels and also fix the vertical GUI order.

Fix Joystick grid layout

The CC labels are not in the same column as the neg/pos icons and they are not aligned well in Dual CC /Single CC mode.
Move the CC labels to the column 0.
Move the entries to the freed column 1.

Fix left/right icons

go-left and go-riight are not included in GTK icons.
Change them to go-previous and go-next.

Fix arpeggiator switch

The arpeggiator fills its cell.
Fix it by setting halign/valign.

Change download/upload icons

The current icons don't describe their purpose enough.
Change them with upload/download notations.


Fix startup without device

Startup without device causes a segmentation fault (at least here).
Show an error if the device_init is not successfull.